### PR TITLE
Fix fonts import

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,8 @@
 <link rel="stylesheet" href="/assets/css/navbar.css" />
 
 <!--=================== cdn ==============================-->
-<link href="https://fonts.googleapis.com/css?family=Muli" rel="stylesheet" />
+<!-- <link href="https://fonts.googleapis.com/css?family=Muli" rel="stylesheet" /> -->
+<link href="https://fonts.googleapis.com/css2?family=Muli:wght@300;400;500;600" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 
 <!--================= fab-icon =========================-->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,6 @@
 <link rel="stylesheet" href="/assets/css/navbar.css" />
 
 <!--=================== cdn ==============================-->
-<!-- <link href="https://fonts.googleapis.com/css?family=Muli" rel="stylesheet" /> -->
 <link href="https://fonts.googleapis.com/css2?family=Muli:wght@300;400;500;600" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 

--- a/static/assets/css/experiences.css
+++ b/static/assets/css/experiences.css
@@ -6,10 +6,6 @@
   margin-top: 1.5rem !important;
 }
 
-.text-muted {
-  color: #e5e9f2;
-}
-
 .experiences ul {
   padding-left: 1rem;
 }

--- a/static/assets/css/experiences.css
+++ b/static/assets/css/experiences.css
@@ -15,10 +15,6 @@
   color: #3c4858;
 }
 
-.experience-entry-heading h5 {
-  font-weight: 600;
-}
-
 .circle {
   padding: 13px 20px;
   border-radius: 50%;

--- a/static/assets/css/list.css
+++ b/static/assets/css/list.css
@@ -98,7 +98,6 @@
   padding: 0 1em;
   line-height: 2em;
   color: #3c4858;
-  font-weight: 700;
   position: relative;
 }
 

--- a/static/assets/css/navbar.css
+++ b/static/assets/css/navbar.css
@@ -20,7 +20,7 @@
 
 .initial-navbar .navbar-brand {
   color: #c0ccda;
-  font-weight: 800;
+  font-weight: 600;
 }
 
 .initial-navbar li a {
@@ -57,7 +57,7 @@
 
 .final-navbar .navbar-brand {
   color: #1c2d41;
-  font-weight: 800;
+  font-weight: 600;
 }
 
 .final-navbar li a {

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -150,10 +150,6 @@ img.right{
   -webkit-transform: scale(1.2);
 }
 
-.card-title {
-  font-weight: 600;
-}
-
 .card-body {
   text-align: justify;
 }


### PR DESCRIPTION
Hi, I detected the current URL is not downloading all the font-weights that theme uses.

`<link href="https://fonts.googleapis.com/css?family=Muli" rel="stylesheet" />`

Currently, it only brings 400 font-weight. Also, I have taken the opportunity to update the URL endpoint.

Due to this change, some parts of the web look different but I think brand text looks bad. For this reason, I adjusted the size from 800 to 600. I preferred to not touch more because the rest is readable and is consistent with the style. 

Please if you think that something has to be changed let me know.