### PR TITLE
Hide "My Resume" button in case the information is missing in config

### DIFF
--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -23,9 +23,11 @@
               {{ end }}
             </ul>
           </div>
+          {{ if .Site.Data.about.resume }}
           <a href="{{ .Site.Data.about.resume }}" target="#"
             ><button class="btn btn-dark">My Resume</button></a
           >
+          {{ end }}
         </div>
         <!-- soft skills circular-progressbar -->
         <div class="col-md-6 pt-5 pl-md-4 pl-sm-3 pt-md-0">


### PR DESCRIPTION
In some cases the user might not fill in the information regarding the resume.
In that case it might make sense to hide the button.