### PR TITLE
If no author specified in blog post, it should default to site author

### DIFF
--- a/layouts/partials/helpers/get-author-image.html
+++ b/layouts/partials/helpers/get-author-image.html
@@ -1,4 +1,7 @@
 {{ $authorImage:= "/assets/images/default-avatar.png"}}
+{{ if .Site.Data.site.author}}
+    {{ $authorImage = .Site.Data.site.author.image | relURL }}
+{{ end}}
 {{ if eq (printf "%T" .Params.author ) "maps.Params" }}
     {{ with .Params.author }}
         {{ if .image }}

--- a/layouts/partials/helpers/get-author-name.html
+++ b/layouts/partials/helpers/get-author-name.html
@@ -1,4 +1,7 @@
 {{ $authorName:= "John Doe"}}
+{{ if .Site.Data.site.author}}
+    {{ $authorName = .Site.Data.site.author.name }}
+{{ end}}
 {{ if eq (printf "%T" .Params.author ) "maps.Params" }}
     {{ with .Params.author }}
         {{ if .name }}


### PR DESCRIPTION
Hi,

I have experienced a weird behaviour if I don't specify an author in the blog post.

For instance for the following blogpost:
```
---
title: "Test"
date: 2020-06-23T20:12:30+02:00
---
```
I would get John Doe as the author.

I think the helpers should look for the site author.