### PR TITLE
Fix experiences line for mobile devices

### DIFF
--- a/static/assets/css/experiences.css
+++ b/static/assets/css/experiences.css
@@ -113,3 +113,43 @@
 
 @media only screen and (max-width: 576px) {
 }
+
+
+/* iPhoneX, iPhone 6,7,8 */
+@media only screen and (max-width: 375px) {
+  .top-left {
+    left: -52%;
+    top: -50%;
+  }
+  
+  .top-right {
+    left: 52%;
+    top: -50%;
+  }
+}
+
+/* Galaxy S5, Moto G4 */
+@media only screen and (max-width: 360px) {
+  .top-left {
+    left: -56%;
+    top: -50%;
+  }
+  
+  .top-right {
+    left: 56%;
+    top: -50%;
+  }
+}
+
+/* iPhone 5 or before */
+@media only screen and (max-width: 320px) {
+  .top-left {
+    left: -64%;
+    top: -50%;
+  }
+  
+  .top-right {
+    left: 64%;
+    top: -50%;
+  }
+}


### PR DESCRIPTION
Hi,

testing some things on mobile I found this little bug. I attach an image

![image](https://user-images.githubusercontent.com/9094374/86069515-674b8380-ba7a-11ea-8413-68cd9b6b3ec7.png)

I used this [guide](https://deviceatlas.com/blog/viewport-resolution-diagonal-screen-size-and-dpi-most-popular-smartphones) to create media-queries for the most popular devices. 

I've not found a more elegant solution. But if you know a better way to fix that feel free to change it.

Thanks for your time!
Pau