### PR TITLE
Side BaseURL removed from single.html

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,7 @@
 {{ define "content" }}
 <div class="container p-0 read-area">
   <!--Hero Area-->
-  <div class="hero-area col-sm-12" style='background-image: url({{ strings.TrimSuffix "/" .Site.BaseURL }}{{ partial "helpers/get-hero.html" . }});'>
+  <div class="hero-area col-sm-12" style='background-image: url({{ partial "helpers/get-hero.html" . }});'>
   </div>
 
   <!--Content Start-->


### PR DESCRIPTION
BaseUrl in single.html file been removed:


when background url is here with BaseURL, 
image is not openning when you accessing your page through some other url.

_example:_
when accessing site instead of: http:/toha.example.com/posts/some-post
you trying to access with: http://127.0.0.1/posts/some-post
or any other domain name