### PR TITLE
added support for the meta description tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ enableEmoji: true
 
 # Custom parameters
 params:
+  # description
+  description: Theme for a personal portfolio with minimalist design and responsiveness
+
   # copyright
   copyright: © 2020 Copyright.
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ enableEmoji: true
 
 # Custom parameters
 params:
-  # description
-  description: Theme for a personal portfolio with minimalist design and responsiveness
-
-  # copyright
+  # Copyright Notice
   copyright: © 2020 Copyright.
+
+  # Meta description for your site.  This will help the search engines to find your site.
+  description: Portfolio and personal blog of Jane Doe.
 
   # background image of the landing page
   background: "images/background.jpg"

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -24,11 +24,11 @@ enableEmoji: true
 
 # Custom parameters
 params:
-  # description
-  description: this is an example site for the Toha theme
-
-  # copyright
+  # Copyright Notice
   copyright: © 2020 Copyright.
+
+  # Meta description for your site.  This will help the search engines to find your site.
+  description: Portfolio and personal blog of Jane Doe.
 
   # background image of the landing page
   background: "images/background.jpg"

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -24,6 +24,9 @@ enableEmoji: true
 
 # Custom parameters
 params:
+  # description
+  description: this is an example site for the Toha theme
+
   # copyright
   copyright: © 2020 Copyright.
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,5 @@
 {{ define "header" }}
+<meta name="description" content="{{.Description}}" />
 <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/atom-one-dark.min.css"
@@ -36,7 +37,7 @@
       <!--Hero Area-->
       <div class="hero-area col-sm-12" id="hero-area" style='background-image: url({{ strings.TrimSuffix "/" .Site.BaseURL }}{{ partial "helpers/get-hero.html" . }});'>
       </div>
-  
+
       <!--Content Start-->
       <div class="page-content">
         <div class="author-profile ml-auto align-self-lg-center">
@@ -44,15 +45,15 @@
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
           <p>{{ .Page.Date.Format "January 2, 2006" }}</p>
         </div>
-  
+
         <div class="title">
           <h1>{{ .Page.Title }}</h1>
         </div>
-  
+
         <div class="post-content" id="post-content">
           {{ .Page.Content }}
         </div>
-  
+
         <!--- Improve this page button --->
         {{ if .Site.Params.GitRepo }}
           <div class="btn-improve-page">
@@ -62,7 +63,7 @@
               </a>
           </div>
         {{ end }}
-  
+
         <!---Next and Previous Navigator -->
       <hr />
         {{ partial "navigators/next-prev-navigator.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "header" }}
-<meta name="description" content="{{.Description}}" />
+<meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Title }}{{ end }}" />
 <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/atom-one-dark.min.css"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>{{- .Site.Title -}}</title>
+    <meta name="description" content="{{ .Site.Params.description }}" />
     <!-- import common headers -->
     {{- partial "header.html" . -}}
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,4 @@
+<meta name="description" content="{{.Site.Params.description}}" />
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="X-UA-Compatible" content="ie=edge" />

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,3 @@
-<meta name="description" content="{{.Site.Params.description}}" />
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="X-UA-Compatible" content="ie=edge" />


### PR DESCRIPTION
It would be nice to have the meta description tag for the search engines.

In this PR:
-  A new parameter `description` has been added for the description on the main site
- Single pages will use the `.Description` [page variable](https://gohugo.io/variables/page/)  to create the meta description tag.