### PR TITLE
Fix: Section Headings not translatable

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -42,7 +42,7 @@
             {{ if .section.template }}
               {{- partial .section.template . -}}
             {{ else }}
-              {{- partial (printf "sections/%s.html" (replace (lower .section.name) " " "-")) . -}}
+              {{- partial (printf "sections/%s.html" (replace (lower .section.id) " " "-")) . -}}
             {{ end }}
           </div>
           <!--- alter background color for next section --->


### PR DESCRIPTION
When trying to change the `name` paramter of the section yaml files in order to translate them to german, I ran into a build error:

> ERROR 2020/10/13 17:50:40 Failed to render pages: render of "home" failed: "[PATH]\themes\toha\layouts\index.html:45:18": execute of template failed: template: index.html:45:18: executing "index.html" at <partial (printf "sections/%s.html" (replace (lower .section.name) " " "-")) .>: error calling partial: partial "sections/projekte.html" not found

The problem seems to be, that it is trying to get the partial path from the `name` parameter, which has to be different in every language and thus will not result in the right file. 

My suggestion in this PR is, to use the `id`-Paramter instead, which should be the same for every language.
