### PR TITLE
Fix the 404 nav bar to use the site configurable logo

### DIFF
--- a/layouts/partials/navigators/navbar-2.html
+++ b/layouts/partials/navigators/navbar-2.html
@@ -1,10 +1,10 @@
 {{ $mainLogo:="assets/images/main-logo.png" }}
 {{ $invertedLogo:="assets/images/inverted-logo.png" }}
-{{ if .Site.Params.logo.main }}
-  {{ $mainLogo = .Site.Params.logo.main }}
+{{ if site.Params.logo.main }}
+  {{ $mainLogo = site.Params.logo.main }}
 {{ end }}
-{{ if .Site.Params.logo.inverted }}
-  {{ $invertedLogo = .Site.Params.logo.inverted }}
+{{ if site.Params.logo.inverted }}
+  {{ $invertedLogo = site.Params.logo.inverted }}
 {{ end }}
 
 <nav class="navbar navbar-expand-xl top-navbar final-navbar shadow">


### PR DESCRIPTION
https://github.com/hossainemruz/toha/issues/103

I'm new to hugo, but from reading https://gohugo.io/variables/site/ it seems the `.` in a partial is the current context. 
The main site navbar.html partial seems to work because the whole site is passed as context https://github.com/hossainemruz/toha/blob/master/layouts/index.html#L26 . However, the 404 nav bar partial doesn't seem to work because a dictionary partial is passed in https://github.com/hossainemruz/toha/blob/master/layouts/404.html#L6

Changing to use the global `site` function appears to fix it. Alternatively i could pass in either the full site object as context or add the .Site.Params.logo as a dictionary item to https://github.com/hossainemruz/toha/blob/master/layouts/404.html#L6

I've consumed this branch in my site to test
![image](https://user-images.githubusercontent.com/8029578/96390699-dbbe4580-1183-11eb-9c6e-6044af7ceda6.png)
https://github.com/alex-bezek/blog/pull/44
https://percy.io/alex-bezek/blog/builds/7343218
https://blog-git-demo-404-logo.alex-bezek.vercel.app/404.html
