### PR TITLE
Update readme with contributing guide and create github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug
+about: File a bug report.
+title: 'bug'
+---
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+### Screenshots
+<!--- Provide any screenshots or links to deployments -->
+
+### Browsers Affected
+<!-- Check all that apply -->
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Edge
+- [ ] Safari 11
+- [ ] Safari 10
+- [ ] IE 11
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: File a Feature Request.
+title: 'Feature Request'
+---
+
+<!---
+Before filing an issue, please review the following:
+  Existing Features: https://github.com/hossainemruz/toha#features
+  Project Roadmap: https://github.com/hossainemruz/toha#project-roadmap
+-->
+
+### Describe the solution you'd like
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+### Describe alternatives you've considered
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+### Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Question
+about: Ask a general question.
+---
+
+<!--- Use this template for general questions. For bug reports or feature requests, please use those templates -->
+
+### Question
+<!--- Insert your question here. Please provide as much detail as possible. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+### Issue
+<!--- Insert a link to the associated github issue here. -->
+
+### Description
+
+<!-- Insert details about what the changes being proposed are. -->
+
+### Test Evidence
+
+<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->

--- a/README.md
+++ b/README.md
@@ -233,16 +233,43 @@ Here, are the current plan and progress of various components of this theme. The
 
 ## Contributing
 
-You can contribute to this theme in various way. You can report a bug, file an feature request, send a PR, share your thoughts etc.
+You can contribute to this theme in various ways. You can report a [bug](https://github.com/hossainemruz/toha/issues/new?template=bug.md), file an [feature request](https://github.com/hossainemruz/toha/issues/new?template=feature_request.md), send a PR, [share your thoughts](https://github.com/hossainemruz/toha/issues/new?template=question.md) etc.
 
-Pull requests are most welcomed and I will be happy to review. Just follow the following principles:
+Pull requests are most welcome and I will be happy to review. Just follow the following principles:
 
 - Keep it simple.
 - Keep it consistent with the design.
-- Use as little dependency as possible.
-- Have patient.
+- Use as few dependencies as possible.
+- Have patience.
 
 >I am not a web developer. I just created this theme for my personal needs. So, it is reasonable to have some flaws in the codes. Feel free to open issues and PR acknowledging the problems.
+
+## Local Development
+
+For local development, you can run your own site or the [example site](https://github.com/hossainemruz/toha-example-site) locally and make changes in the theme submodule.
+
+### Fork
+Fork [this repo](https://github.com/hossainemruz/toha) and setup your local submodule with the following from the site's folder by running the following
+
+```sh
+git submodule update --init --recursive --remote
+cd themes/toha
+git remote add my-fork https://github.com/<your-github-user>/toha
+git checkout -b my-feature-branch
+```
+
+From there you can make changes to the source code of the theme while testing with your running Hugo site.
+
+### Open a PR
+
+When the changes look good, commit and push them to your fork
+```sh
+git add .
+git commit -m "A meaningful commit message"
+git push my-fork my-feature-branch
+```
+
+And then open a PR `https://github.com/<your-github-user></your-github-user>/toha/pull/new/my-feature-branch`
 
 ## Attribution
 


### PR DESCRIPTION
### Issue
Fixes #105

### Description

* Adds specific workflow steps to the readme on contributing using a git submodule. I have never worked with them so this was something i had to figure out. might be useful for others
* Added issue and PR templates linked in the contributing section. These are just useful at work and thought they would be helpful
* Minor spelling/grammar changes

### Test Evidence
* Readme https://github.com/alex-bezek/toha#local-development
* Issue list https://github.com/alex-bezek/toha/issues/new/choose
* Issue examples
  * https://github.com/alex-bezek/toha/issues/new?template=question.md
  * https://github.com/alex-bezek/toha/issues/new?template=feature_request.md&title=Feature+Request
  * https://github.com/alex-bezek/toha/issues/new?template=bug.md&title=bug
