### PR TITLE
Add nav item data and aria attributes to collapse the nav bar in mobile

### DIFF
--- a/layouts/partials/navigators/navbar.html
+++ b/layouts/partials/navigators/navbar.html
@@ -31,7 +31,16 @@
     <div class="collapse navbar-collapse" id="top-nav-items">
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-          <a class="nav-link" href="#home">{{ i18n "home" }}</a>
+          <a
+            class="nav-link"
+            href="#home"
+            data-toggle="collapse"
+            data-target=".navbar-collapse"
+            aria-controls="collapseExample"
+            role="button"
+          >
+            {{ i18n "home" }}
+          </a>
         </li>
         {{ if $sections }}
           {{ range sort $sections "section.weight" }}
@@ -41,7 +50,15 @@
                 {{ $sectionID = .section.id }}
               {{ end }}
               <li class="nav-item">
-                <a class="nav-link" href="#{{ $sectionID }}">{{ .section.name }}</a>
+                <a
+                  class="nav-link"
+                  href="#{{ $sectionID }}"
+                  data-toggle="collapse"
+                  data-target=".navbar-collapse"
+                  aria-controls="collapseExample"
+                >
+                  {{ .section.name }}
+                </a>
               </li>
             {{ end }}
           {{- end }}


### PR DESCRIPTION
…le when an item is clicked
https://github.com/hossainemruz/toha/issues/102

Tested on desktop chrome. Recreated the issue and then updated the nav links following https://getbootstrap.com/docs/4.0/components/collapse/
added a couple of aria attributes they recommended as well