### PR TITLE
Fix about section to pull author name correctly

### DIFF
--- a/layouts/partials/sections/about.html
+++ b/layouts/partials/sections/about.html
@@ -1,13 +1,19 @@
+
 {{ $sectionID := replace (lower .section.name) " " "-"  }}
 {{ if .section.id }}
   {{ $sectionID = .section.id }}
+{{ end }}
+
+{{ $author:= site.Data.author }}
+{{ if (index site.Data site.Language.Lang).author }}
+  {{ $author = (index site.Data site.Language.Lang).author }}
 {{ end }}
 
 <div class="container anchor p-lg-5 about-section" id="{{ $sectionID }}">
   <div class="row pt-sm-2 pt-md-4 align-self-center">
     <!-- summary -->
     <div class="col-sm-6">
-    <h3 class="p-1">{{ site.Params.author.name }}</h3>
+      <h3 class="p-1">{{ $author.name }}</h3>
       {{ if .designation }}
       <h5 class="p-1">
         {{ .designation }}

--- a/layouts/partials/sections/about.html
+++ b/layouts/partials/sections/about.html
@@ -1,4 +1,3 @@
-
 {{ $sectionID := replace (lower .section.name) " " "-"  }}
 {{ if .section.id }}
   {{ $sectionID = .section.id }}


### PR DESCRIPTION
Addresses https://github.com/hossainemruz/toha/issues/113

Existing issue has name not showing up in the about section ![image](https://user-images.githubusercontent.com/8029578/96673257-1a92fd80-1334-11eb-9079-58f28addbc60.png)

With this update it seems to pull correctly
![image](https://user-images.githubusercontent.com/8029578/96673327-43b38e00-1334-11eb-9208-ad2300a0258e.png)