### PR TITLE
add ios specific css for fixing the background images

### DIFF
--- a/static/assets/css/sections/home.css
+++ b/static/assets/css/sections/home.css
@@ -18,6 +18,19 @@
   background-size: cover;
 }
 
+/*
+  Resolves https://github.com/hossainemruz/toha/issues/70
+
+  fixed attached images use the whole <body> size. On mobile this can get really
+  tall which blows your image out. Setting the attachment back to scroll allows
+  your cover image to stretch within its own container
+*/
+@supports (-webkit-touch-callout: none) {
+  .background {
+    background-attachment: scroll;
+  }
+}
+
 .content {
   position: relative;
   top: -65%;


### PR DESCRIPTION
Fixes https://github.com/hossainemruz/toha/issues/70

Read more into the comments of https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios which linked to https://stackoverflow.com/questions/30102792/css-media-query-to-target-only-ios-devices/47818418#47818418

I made that change and branch deployed it to my site to test
https://github.com/alex-bezek/blog/pull/50
https://blog-git-test-ios-background-image-fix.alex-bezek.vercel.app/
![image](https://user-images.githubusercontent.com/8029578/96679563-e0c8f380-1341-11eb-96c2-fa145692c8fc.png)

Tested in safari and firefox desktop as well
![image](https://user-images.githubusercontent.com/8029578/96679787-56cd5a80-1342-11eb-86dc-a9a3dd7721b5.png)
![image](https://user-images.githubusercontent.com/8029578/96679924-9005ca80-1342-11eb-87c0-4f695f83b1cb.png)


If anyone has an android and an ipad those would be good to test. I'll do some more reading about best practices using this css attribute as well since right now i'm just kind of trusting in stack overflow :)