### PR TITLE
fix URLs when serving from a subdirectory (fixes #89)

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 {{ define "header" }}
-    <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="{{ "/assets/css/404.css" | relURL }}">
 {{ end }}
 
 {{ define "navbar" }}
@@ -9,7 +9,7 @@
 {{ define "content" }}
 <div class="container">
     <div class="notFound">
-        <img src="/assets/images/404.png" alt="">
+        <img src="{{ "/assets/images/404.png" | relURL }}" alt="">
         <div class="message">
             <h1>404</h1>
             <h4>The page you are looking for is not there yet.</h4>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ define "header" }}
-    <link rel="stylesheet" href="/assets/css/layouts/list.css">
-    <link rel="stylesheet" href="/assets/css/navigators/sidebar.css">
+    <link rel="stylesheet" href="{{ "/assets/css/layouts/list.css" | relURL }}">
+    <link rel="stylesheet" href="{{ "/assets/css/navigators/sidebar.css" | relURL}}">
 {{ end }}
 
 {{ define "navbar" }}
@@ -47,5 +47,5 @@
 {{ end }}
 
 {{ define "scripts" }}
-    <script src="/assets/js/list.js"></script>
+    <script src="{{ "/assets/js/list.js" | relURL }}"></script>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,8 +4,8 @@
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/atom-one-dark.min.css"
 />
-<link rel="stylesheet" href="/assets/css/layouts/single.css" />
-<link rel="stylesheet" href="/assets/css/navigators/sidebar.css">
+<link rel="stylesheet" href="{{ "/assets/css/layouts/single.css" | relURL }}"/>
+<link rel="stylesheet" href="{{ "/assets/css/navigators/sidebar.css" | relURL }}">
 {{ end }}
 
 {{ define "navbar" }}
@@ -97,7 +97,7 @@
 
 {{ define "scripts" }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js"></script>
-<script src="/assets/js/single.js"></script>
+<script src="{{ "/assets/js/single.js" | relURL }}"></script>
 <script>
   hljs.initHighlightingOnLoad();
 </script>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,13 +7,13 @@
     {{- partial "header.html" . -}}
 
     <!-- import index page specific headers -->
-    <link rel="stylesheet" href="/assets/css/sections/home.css" />
-    <link rel="stylesheet" href="/assets/css/sections/about.css" />
-    <link rel="stylesheet" href="/assets/css/sections/skills.css" />
-    <link rel="stylesheet" href="/assets/css/sections/experiences.css" />
-    <link rel="stylesheet" href="/assets/css/sections/projects.css" />
-    <link rel="stylesheet" href="/assets/css/sections/recent-posts.css" />
-    <link rel="stylesheet" href="/assets/css/sections/achievements.css" />
+    <link rel="stylesheet" href="{{ "/assets/css/sections/home.css" | relURL }}"/>
+    <link rel="stylesheet" href="{{ "/assets/css/sections/about.css" | relURL }}"/>
+    <link rel="stylesheet" href="{{ "/assets/css/sections/skills.css" | relURL }}"/>
+    <link rel="stylesheet" href="{{ "/assets/css/sections/experiences.css" | relURL }}"/>
+    <link rel="stylesheet" href="{{ "/assets/css/sections/projects.css" | relURL }}"/>
+    <link rel="stylesheet" href="{{ "/assets/css/sections/recent-posts.css" | relURL }}"/>
+    <link rel="stylesheet" href="{{ "/assets/css/sections/achievements.css" | relURL }}"/>
 
     <!-- Add Google Analytics if enabled in configuration -->
     {{ if .Site.GoogleAnalytics }}
@@ -62,9 +62,9 @@
     {{ partial "scripts.html" . }}
 
     <!--- ADD INDEX PAGE SPECIFIC SCRIPTS -->
-    <script src="/assets/js/itype.min.js"></script>
-    <script src="/assets/js/github-button.js"></script>
-    <script src="/assets/js/home.js"></script>
-    <script src="/assets/js/jquery.filterizr.min.js"></script>
+    <script src="{{ "/assets/js/itype.min.js" | relURL }}"></script>
+    <script src="{{ "/assets/js/github-button.js" | relURL }}"></script>
+    <script src="{{ "/assets/js/home.js" | relURL }}"></script>
+    <script src="{{ "/assets/js/jquery.filterizr.min.js" | relURL }}"></script>
   </body>
 </html>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -76,7 +76,7 @@
     <div class="row text-left">
       <div class="col-md-4">
         <a id="theme" href="https://github.com/hossainemruz/toha" target="#">
-          <img src="/assets/images/inverted-logo.png">
+          <img src="{{ "/assets/images/inverted-logo.png" | relURL }}">
           Toha
         </a>
       </div>
@@ -84,7 +84,7 @@
       <div class="col-md-4 text-right">
         <a id="hugo" href="https://gohugo.io/">{{ i18n "hugoAttributionText" }}
         <img
-          src="/assets/images/hugo-logo-wide.svg"
+          src="{{ "/assets/images/hugo-logo-wide.svg" | relURL }}"
           alt="Hugo Logo"
           height="18"
         />

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,10 +3,10 @@
 <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
 <!-- ============ import common css ========== -->
-<link rel="stylesheet" href="/assets/css/bootstrap.min.css" />
-<link rel="stylesheet" href="/assets/css/layouts/main.css" />
-<link rel="stylesheet" href="/assets/css/style.css" />
-<link rel="stylesheet" href="/assets/css/navigators/navbar.css" />
+<link rel="stylesheet" href="{{ "/assets/css/bootstrap.min.css" | relURL }}"/>
+<link rel="stylesheet" href="{{ "/assets/css/layouts/main.css" | relURL }}"/>
+<link rel="stylesheet" href="{{ "/assets/css/style.css" | relURL }}"/>
+<link rel="stylesheet" href="{{ "/assets/css/navigators/navbar.css" | relURL }}"/>
 
 <!--=================== cdn ==============================-->
 <link href="https://fonts.googleapis.com/css2?family=Muli:wght@300;400;500;600" rel="stylesheet">
@@ -16,4 +16,4 @@
 <link rel="icon" type="image/png" href="{{ .Site.Params.logo.favicon | default "/assets/images/favicon.png" | absURL }}" />
 
 <!--================= custom style overrides =========================-->
-<link rel="stylesheet" href="/assets/css/style.css" />
+<link rel="stylesheet" href="{{ "/assets/css/style.css" | relURL }}"/>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,6 +1,6 @@
-<script src="/assets/js/jquery-3.4.1.min.js"></script>
-<script src="/assets/js/popper.min.js"></script>
-<script src="/assets/js/bootstrap.min.js"></script>
+<script src="{{ "/assets/js/jquery-3.4.1.min.js" | relURL }}"></script>
+<script src="{{ "/assets/js/popper.min.js" | relURL }}"></script>
+<script src="{{ "/assets/js/bootstrap.min.js" | relURL }}"></script>
 
-<script src="/assets/js/navbar.js"></script>
-<script src="/assets/js/main.js"></script>
+<script src="{{ "/assets/js/navbar.js" | relURL }}"></script>
+<script src="{{ "/assets/js/main.js" | relURL }}"></script>


### PR DESCRIPTION
Currently, when hugo has a baseURL in a subdirectory, many links aren't adhering to the subdirectory, but instead linking to the root directory. This fixes issue #89 by adding the proper relURL in every place where it is needed.