### PR TITLE
Fix the site meta description to pull from the localized site data

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,14 @@
 <html lang="en">
   <head>
     <title>{{- .Site.Title -}}</title>
-    <meta name="description" content="{{ .Site.Params.description }}" />
+    {{ $siteDescription := .Site.Params.description }}
+    {{ if (index .Site.Data .Site.Language.Lang).site }}
+      {{ $siteConfig := (index .Site.Data .Site.Language.Lang).site }}
+      {{ if $siteConfig.description }}
+        {{ $siteDescription = $siteConfig.description }}
+      {{ end }}
+    {{ end }}
+    <meta name="description" content="{{ $siteDescription }}" />
     <!-- import common headers -->
     {{- partial "header.html" . -}}
 


### PR DESCRIPTION
### Issue
https://github.com/hossainemruz/toha/issues/108

### Description

The site's description used to live in the `config.yml` file. However, in the recent localization updates it should be moved to the `./data/<locale>/site.yml` file so its properly localized. The index file however is still referencing the old config option. This changes it to pull from the new localized section while also falling back to the top level config.yml for passivity. 

### Test Evidence

Before:
![image](https://user-images.githubusercontent.com/8029578/97084870-c748d580-15e7-11eb-84f9-58e95780b7fe.png)

After:
![image](https://user-images.githubusercontent.com/8029578/97084875-cca62000-15e7-11eb-82d9-f6adf9f83e87.png)
